### PR TITLE
Fix file header for ELPA compatibility

### DIFF
--- a/foreign-regexp.el
+++ b/foreign-regexp.el
@@ -6,6 +6,7 @@
 ;; Created: Sun Nov 28 23:50:45 2010 JST
 ;; Keywords: convenience emulations matching tools unix wp
 ;; Revision: $Id$
+;; Version: 0.0
 ;; URL: 
 ;; GitHub: http://github.com/k-talo/foreign-regexp.el
 


### PR DESCRIPTION
With this fix, the file can be installed using `package.el`, e.g.
from the convenient packages automatically built by
MELPA ([http://melpa.milkbox.net](http://melpa.milkbox.net)).

The fix is according to [the marmalade package format](http://marmalade-repo.org/doc-files/package.5.html).
