### PR TITLE
Update foreign-regexp.el

### DIFF
--- a/foreign-regexp.el
+++ b/foreign-regexp.el
@@ -3855,7 +3855,7 @@ to each search option changed hook."
 ;;       *RE-Builder* buffer. So here we made a patch which corrects
 ;;       that behavior.
 
-(defvar foreign-regexp/re-builder/targ-buf-state/.orig-pt)
+(defvar foreign-regexp/re-builder/targ-buf-state/.orig-pt nil)
 
 
 ;; ----------------------------------------------------------------------------


### PR DESCRIPTION
this kills the warning